### PR TITLE
Bump gem versions

### DIFF
--- a/lita-hipchat.gemspec
+++ b/lita-hipchat.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">=2.0"
-  spec.add_runtime_dependency "xmpp4r", "~> 0.5"
+  spec.add_runtime_dependency "lita", "~> 3.3.1"
+  spec.add_runtime_dependency "xmpp4r", "~> 0.5.6"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.7.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
Bring gem dependencies up to date. Use latest Lita v3.0

There's a notice in README that `lita-hipchat` can be used instead for generic xmpp chats, but it's actually not true since `lita-hipchat` adapter has some hipchat-specific configurations and doesn't work with other xmpp chats.

I got this plugin working with latest Lita by fixing a couple issues.
