### PR TITLE
Lita config is frozen since 3.0.0 and xmpp4r will try to downcase! @domain

### DIFF
--- a/lib/lita/adapters/xmpp/connector.rb
+++ b/lib/lita/adapters/xmpp/connector.rb
@@ -39,7 +39,7 @@ module Lita
         def join_rooms(muc_domain, rooms)
           rooms.each do |room_name|
             muc = Jabber::MUC::SimpleMUCClient.new(client)
-            room_jid = normalized_jid(room_name, muc_domain, robot.name)
+            room_jid = normalized_jid(room_name, muc_domain.dup, robot.name)
             mucs[room_jid.bare.to_s] = muc
             register_muc_message_callback(muc)
             Lita.logger.info("Joining room: #{room_jid}.")


### PR DESCRIPTION
Lita xmpp adapter fails with "can't modify frozen String" when trying to join rooms.

Since 3.0.0 Lita has it's config frozen:

```
lita-3.3.1/lib/lita/config.rb:
 83     # Deeply freezes the object to prevent any further mutation.
 84     # @return [void]
 85     # @since 3.0.0
 86     def finalize
 87       IceNine.deep_freeze!(self)
 88     end
```

This causes lita-xmpp adapter to fail with:

```
/u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/jid.rb:41:in `downcase!': can't modify frozen String (RuntimeError)
    from /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/jid.rb:41:in `initialize'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/jid.rb:67:in `new'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/jid.rb:67:in `strip'
    from /u/apps/lita/vendor/ruby/2.1.0/bundler/gems/lita-xmpp-50008c2b973b/lib/lita/adapters/xmpp/connector.rb:43:in `block in join_rooms'
    from /u/apps/lita/vendor/ruby/2.1.0/bundler/gems/lita-xmpp-50008c2b973b/lib/lita/adapters/xmpp/connector.rb:40:in `each'
    from /u/apps/lita/vendor/ruby/2.1.0/bundler/gems/lita-xmpp-50008c2b973b/lib/lita/adapters/xmpp/connector.rb:40:in `join_rooms'
    from /u/apps/lita/vendor/ruby/2.1.0/bundler/gems/lita-xmpp-50008c2b973b/lib/lita/adapters/xmpp.rb:27:in `run'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/lita-3.3.1/lib/lita/robot.rb:47:in `run'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/lita-3.3.1/lib/lita.rb:141:in `run'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/lita-3.3.1/lib/lita/cli.rb:75:in `start'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /u/apps/lita/vendor/ruby/2.1.0/gems/lita-3.3.1/bin/lita:6:in `<top (required)>'
    from /u/apps/lita/bin/lita:16:in `load'
    from /u/apps/lita/bin/lita:16:in `<main>'
```

xmpp4r is trying to modify config in initialization:

```
 26     def initialize(node = "", domain = nil, resource = nil)
...
 38       else
 39         @node.downcase! if @node
 40         @domain.downcase! if @domain
 41       end
```
