### PR TITLE
Source initialize method expects hashes to be passed

### DIFF
--- a/lib/lita/adapters/xmpp/callback.rb
+++ b/lib/lita/adapters/xmpp/callback.rb
@@ -14,7 +14,7 @@ module Lita
           client.add_message_callback do |m|
             next if m.type == :error || m.body.nil?
             user = user_by_jid(m.from)
-            source = Source.new(user)
+            source = Source.new(user: user)
             message = Message.new(robot, m.body, source)
             message.command!
             Lita.logger.debug("Dispatching PM to Lita from #{user.id}.")
@@ -29,7 +29,7 @@ module Lita
               next
             else
               user = user_by_name(nick)
-              source = Source.new(user, muc.jid.bare.to_s)
+              source = Source.new(user: user, room: muc.jid.bare.to_s)
               message = Message.new(robot, text, source)
               Lita.logger.debug(
                 "Dispatching message to Lita from #{user.id} in MUC #{muc.jid}."


### PR DESCRIPTION
Fix for

```
W, [2014-09-12T09:48:41.226396 #20236]  WARN -- : EXCEPTION:
    ArgumentError
    wrong number of arguments (2 for 0)
    /u/apps/lita/vendor/ruby/2.1.0/gems/lita-3.3.1/lib/lita/source.rb:30:in `initialize'
    /u/apps/lita/vendor/ruby/2.1.0/bundler/gems/lita-xmpp-50008c2b973b/lib/lita/adapters/xmpp/callback.rb:32:in `new'
    /u/apps/lita/vendor/ruby/2.1.0/bundler/gems/lita-xmpp-50008c2b973b/lib/lita/adapters/xmpp/callback.rb:32:in `block in muc_message'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/muc/helper/simplemucclient.rb:113:in `call'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/muc/helper/simplemucclient.rb:113:in `handle_message'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/muc/helper/mucclient.rb:379:in `block in activate'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/callbacks.rb:99:in `call'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/callbacks.rb:99:in `block in process'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/callbacks.rb:98:in `each'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/callbacks.rb:98:in `process'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/stream.rb:277:in `receive'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/streamparser.rb:74:in `block in parse'
    /opt/ruby2.1.2/lib/ruby/2.1.0/rexml/parsers/sax2parser.rb:142:in `call'
    /opt/ruby2.1.2/lib/ruby/2.1.0/rexml/parsers/sax2parser.rb:142:in `block in parse'
    /opt/ruby2.1.2/lib/ruby/2.1.0/rexml/parsers/sax2parser.rb:142:in `each'
    /opt/ruby2.1.2/lib/ruby/2.1.0/rexml/parsers/sax2parser.rb:142:in `parse'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/streamparser.rb:91:in `parse'
    /u/apps/lita/vendor/ruby/2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/stream.rb:75:in `block in start'
```

See Source initialize method:

```
    def initialize(user: nil, room: nil, private_message: false)
```
