### PR TITLE
Upgrade to Lita 4 (config.adapter deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ There's no need to set `config.robot.mention_name` manually. The adapter will lo
 Lita.configure do |config|
   config.robot.name = "Lita Bot"
   config.robot.adapter = :xmpp
-  config.adapter.jid = "12345_123456@myserver.com"
-  config.adapter.password = "secret"
-  config.adapter.debug = false
-  config.adapter.rooms = :all
-  config.adapter.muc_domain = "conf.myserver.com"
+  config.adapters.xmpp.jid = "12345_123456@myserver.com"
+  config.adapters.xmpp.password = "secret"
+  config.adapters.xmpp.debug = false
+  config.adapters.xmpp.rooms = :all
+  config.adapters.xmpp.muc_domain = "conf.myserver.com"
   config.mention_name = "bot"
 end
 ```

--- a/lib/lita/adapters/xmpp.rb
+++ b/lib/lita/adapters/xmpp.rb
@@ -4,14 +4,17 @@ require "lita/adapters/xmpp/connector"
 module Lita
   module Adapters
     class Xmpp < Adapter
-      require_configs :jid, :password
+      config :jid, type: String, required: true
+      config :password, type: String, required: true
+      config :debug, types: [TrueClass, FalseClass], default: false
+      config :rooms, type: Array
+      config :muc_domain, type: String
+      config :connect_domain, type: String
 
       attr_reader :connector
 
       def initialize(robot)
         super
-
-        set_default_config_values
 
         @connector = Connector.new(
           robot,
@@ -57,7 +60,7 @@ module Lita
       private
 
       def config
-        Lita.config.adapter
+        Lita.config.adapters.xmpp
       end
 
       def rooms
@@ -66,10 +69,6 @@ module Lita
         else
           Array(config.rooms)
         end
-      end
-
-      def set_default_config_values
-        config.debug = false if config.debug.nil?
       end
     end
 

--- a/lita-xmpp.gemspec
+++ b/lita-xmpp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-xmpp"
-  spec.version       = "1.1.0.pre"
+  spec.version       = "1.2.0"
   spec.authors       = ["Justin Mazzi"]
   spec.email         = ["jmazzi@gmail.com"]
   spec.description   = %q{A XMPP adapter for Lita.}
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata = {"lita_plugin_type" => "adapter"}
 
-  spec.add_runtime_dependency "lita", ">= 3.0"
+  spec.add_runtime_dependency "lita", ">= 4.0"
   spec.add_runtime_dependency "xmpp4r"
 
   spec.add_development_dependency "bundler", "~> 1.7.2"

--- a/spec/lita/adapters/hipchat_spec.rb
+++ b/spec/lita/adapters/hipchat_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe Lita::Adapters::HipChat do
   before do
     Lita.configure do |config|
-      config.adapter.jid = "jid"
-      config.adapter.password = "secret"
-      config.adapter.rooms = nil
-      config.adapter.muc_domain = nil
+      config.adapters.xmpp.jid = "jid"
+      config.adapters.xmpp.password = "secret"
+      config.adapters.xmpp.rooms = nil
+      config.adapters.xmpp.muc_domain = nil
     end
 
     allow(described_class::Connector).to receive(:new).and_return(connector)
@@ -50,7 +50,7 @@ describe Lita::Adapters::HipChat do
 
     it "joins all rooms when config.rooms is :all" do
       all_rooms = ["room_1_id", "room_2_id"]
-      Lita.config.adapter.rooms = :all
+      Lita.config.adapters.xmpp.rooms = :all
       allow(subject.connector).to receive(:list_rooms).with(
         "conf.hipchat.com"
       ).and_return(all_rooms)
@@ -63,7 +63,7 @@ describe Lita::Adapters::HipChat do
 
     it "joins rooms specified by config.rooms" do
       custom_rooms = ["my_room_1_id", "my_room_2_id"]
-      Lita.config.adapter.rooms = custom_rooms
+      Lita.config.adapters.xmpp.rooms = custom_rooms
       expect(subject.connector).to receive(:join_rooms).with(
         "conf.hipchat.com",
         custom_rooms


### PR DESCRIPTION
This causes lita-xmpp to use the new adapter configuration scheme that [Lita 4 introduced](http://docs.lita.io/releases/4/), and Lita 5 will require.
